### PR TITLE
Este cambio hace que se tenga que borrar la tabla de BD de Payment

### DIFF
--- a/payment/src/main/java/com/kynsoft/finamer/payment/infrastructure/identity/Payment.java
+++ b/payment/src/main/java/com/kynsoft/finamer/payment/infrastructure/identity/Payment.java
@@ -97,7 +97,7 @@ public class Payment implements Serializable {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "payment")
     private List<PaymentDetail> paymentDetails;
 
-    @Column(precision = 2)
+    //@Column(precision = 2)
     private Double paymentAmount;
     private Double paymentBalance;
     private Double depositAmount;


### PR DESCRIPTION
Dado que la propiedad que se agrego a 
    //@Column(precision = 2)
    private Double paymentAmount;
Estaba probocando un redondeo incorrecto.